### PR TITLE
Changes to embedding logging in Comet TensorboardX Integration

### DIFF
--- a/tensorboardX/comet_utils.py
+++ b/tensorboardX/comet_utils.py
@@ -226,7 +226,7 @@ class CometLogger:
     def log_embedding(self, vectors, labels, image_data=None,
                       image_preprocess_function=None, image_transparent_color=None,
                       image_background_color_function=None, title="Comet Embedding",
-                      template_filename="template_projector_config.json",
+                      template_filename=None,
                       group=None):
         """Log a multi-dimensional dataset and metadata for viewing
            with Comet's Embedding Projector (experimental).

--- a/tensorboardX/writer.py
+++ b/tensorboardX/writer.py
@@ -1098,7 +1098,13 @@ class SummaryWriter(object):
         # new funcion to append to the config file a new embedding
         append_pbtxt(metadata, label_img,
                      self._get_file_writer().get_logdir(), subdir, global_step, tag)
-        self.comet_logger.log_embedding(mat, metadata, label_img)
+        if tag is not None:
+            template_filename = "%s.json" % tag
+            
+        else:
+            template_filename = None
+                    
+        self.comet_logger.log_embedding(mat, metadata, label_img, template_filename=template_filename)
 
     def add_pr_curve(
             self,


### PR DESCRIPTION
This PR:

1. Changes the default value of the `template_filename` arg in the comet logger to None. Comet will auto generate a filename for the embedding when None is provided, so there is no need to set a default value here. 
2. Use the tag arg in the SummaryWriter `add_embedding` method to generate a filename for the embedding